### PR TITLE
修复mod和refresh的bug

### DIFF
--- a/Reisen/mod/mod/mod.h
+++ b/Reisen/mod/mod/mod.h
@@ -54,6 +54,8 @@ Mod DisableSpecialAttack{
 // 卡片不消耗阳光且无冷却时间，紫卡可直接种植
 Mod FreePlantingCheat{
     {{0x6a9ec0, 0x814}, '\x01', '\x00'},
+    {0x487296, '\x70', '\x7e'}, // 此二行为取消冷却时间，若无AvZ会报“卡片还有Xcs才能使用”错误
+    {0x488250, '\xeb', '\x75'},
 };
 
 // 蘑菇免唤醒

--- a/Reisen/refresh/refresh/refresh.h
+++ b/Reisen/refresh/refresh/refresh.h
@@ -77,7 +77,7 @@ void Script() {
     }
 
     EnableModsScoped(SaveDataReadOnly, FreePlantingCheat, PlantAnywhere, CobInstantRecharge,
-        DisableItemDrop, PlantInvincible, DisableSpecialAttack, CobFixedDelay);
+        DisableItemDrop, PlantInvincible, DisableSpecialAttack, CobFixedDelay, MushroomAwake);
     OpenMultipleEffective('Q', MAIN_UI_OR_FIGHT_UI);
     if(!cur_task->debug)
         SkipTick([](){ return true; });


### PR DESCRIPTION
# 问题
AvZ_221001运行refresh 1.1.2+avz1的refresh/example/PE-activate.cpp：
- AvZ报“卡片还有Xcs才能使用”错误，原因在于mod.h里的FreePlantingCheat应该只开启了游戏内置的FreePlantingCheat，但没有取消冷却时间，导致AvZ判断卡片还没有恢复而无法使用
- refresh.h没有开启蘑菇免唤醒，导致脚本逻辑出错

# 修复方式
- 在mod.h的FreePlantingCheat里增加取消冷却时间
- 在refresh.h里增加启用MushroomAwake

# 测试
修改后，可以正常运行PE-activate.cpp